### PR TITLE
Add ability to define a 'canDownload()' method on a custom File DataExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": "~3.1",
-		"silverstripe/cms": "~3.1"
+		"silverstripe/framework": "~3.1"
+	},
+	"suggest": {
+		"silverstripe/cms": "Allows you to easily edit file permissions in the CMS"
 	}
 }

--- a/tests/SecureFileControllerTest.php
+++ b/tests/SecureFileControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+class SecureFileControllerTest extends FunctionalTest {
+	static $fixture_file = 'SecureFileControllerTest.yml';
+
+	public function testCanDownloadPermissivePermission() {
+		File::add_extension('SecureFileExtensionTest_PermissiveFileExtension');
+
+		$file = $this->objFromFixture('File', 'permissive');
+		Session::set('loggedInAs', null); // Logout, this file is only for LoggedInUsers, but extension should override
+		$content = $this->get($file->Filename);
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+
+		File::remove_extension('SecureFileExtensionTest_PermissiveFileExtension');
+	}
+
+	public function testCanDownloadRestrictivePermission() {
+		File::add_extension('SecureFileExtensionTest_RestrictiveFileExtension');
+
+		$oldAFR = $this->autoFollowRedirection;
+		$this->autoFollowRedirection = false;
+
+		$file = $this->objFromFixture('File', 'restrictive');
+		$content = $this->get($file->Filename); // This file lets anyone access it, but our extension should override
+		$this->assertTrue($content->getStatusCode() === 302); // Should redirect to Security/login
+		$this->assertContains('Security/login', $content->getHeader('Location'));
+
+		$this->autoFollowRedirection = $oldAFR;
+
+		File::remove_extension('SecureFileExtensionTest_RestrictiveFileExtension');
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		if(!file_exists(ASSETS_PATH)) mkdir(ASSETS_PATH);
+
+		/* Create a test files for each of the fixture references */
+		$fileIDs = $this->allFixtureIDs('File');
+		foreach($fileIDs as $fileID) {
+			$file = DataObject::get_by_id('File', $fileID);
+			$fh = fopen(BASE_PATH."/$file->Filename", "w");
+			fwrite($fh, str_repeat('x',1000000));
+			fclose($fh);
+		}
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		/* Remove the test files that we've created */
+		$fileIDs = $this->allFixtureIDs('File');
+		foreach($fileIDs as $fileID) {
+			$file = DataObject::get_by_id('File', $fileID);
+			if($file && file_exists(BASE_PATH."/$file->Filename")) unlink(BASE_PATH."/$file->Filename");
+		}
+
+		// Remove left over folders and any files that may exist
+		if(file_exists('../assets/FileTest.txt')) unlink('../assets/FileTest.txt');
+	}
+}
+
+class SecureFileExtensionTest_PermissiveFileExtension extends DataExtension implements TestOnly {
+	public function canDownload() {
+		return true;
+	}
+}
+
+class SecureFileExtensionTest_RestrictiveFileExtension extends DataExtension implements TestOnly {
+	public function canDownload() {
+		return false;
+	}
+}

--- a/tests/SecureFileControllerTest.yml
+++ b/tests/SecureFileControllerTest.yml
@@ -1,0 +1,22 @@
+Group:
+  test-group:
+    Name: Test Group
+Member:
+  member-1:
+    FirstName: Joe
+    Email: joe@test.com
+    Groups: =>Group.test-group
+  member-2:
+    FirstName: Steve
+    Email: steve@test.com
+File:
+  permissive:
+    Name: test-file
+    Filename: assets/FileTest.txt
+    CanViewType: LoggedInUsers
+    # CanViewType: OnlyTheseUsers
+    # ViewerGroups: =>Group.test-group
+  restrictive:
+    Name: test-file2
+    Filename: assets/FileTest2.txt
+    CanViewType: anyone

--- a/tests/SecureFileExtensionTest.yml
+++ b/tests/SecureFileExtensionTest.yml
@@ -23,3 +23,7 @@ Folder:
   child-viewergroups-open:
     CanViewType: Anyone
     Parent: =>Folder.viewergroups
+File:
+  test:
+    Name: test-file
+    Filename: assets/FileTest.txt


### PR DESCRIPTION
- If a FileExtension includes a canDownload() method, then use the boolean
  output from that extension to determine access rights. If there are no
  FileExtension objects with canDownload() set, then fallback to using the
  existing canView() permission checks.
- Abstracts the permission checking working into
  SecureFileController::canDownloadFile() rather than directly in handleRequest().
- Fixes bug where the Security::permissionFailure() call fails because no
  SS_HTTPResponse object exists.
- Remove silverstripe/cms from composer require, add to suggests instead.
