### PR TITLE
Improvement for large files and files with spaces within filename

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -56,12 +56,15 @@ class SecureFileController extends Controller {
 		}
 
 		header('Content-Description: File Transfer');
-		header('Content-Disposition: inline; filename=' . basename($path));
+		header('Content-Disposition: inline; filename="' . basename($path) . '"'); // Fixes "Filenames with spaces are truncated upon download" - Problem (http://kb.mozillazine.org/Filenames_with_spaces_are_truncated_upon_download)
 		header('Content-Length: ' . $file->getAbsoluteSize());
 		header('Content-Type: ' . HTTP::get_mime_type($file->getRelativePath()));
 		header('Content-Transfer-Encoding: binary');
 		header('Pragma: '); // Fixes IE6,7,8 file downloads over HTTPS bug (http://support.microsoft.com/kb/812935)
 
+		set_time_limit(0);
+		ob_end_flush();
+		session_write_close();
 		readfile($path);
 		die();
 	}


### PR DESCRIPTION
Improvement for files with spaces within filename:
added quotes to header filename=...
Improvements for downloads of large files:
set_time_limit(0) prevent PHP from stopping the process
ob_end_flush() clear PHP buffer
session_write_close() stops blocking the session file of PHP. Without this, the user can't visit another page of the same website during download (see: http://konrness.com/php5/how-to-prevent-blocking-php-requests/ )
Remark: Apache Config has to be changed as well e.g.
<IfModule mod_fcgid.c>
    FcgidBusyTimeout 3600
</IfModule>
