### PR TITLE
BUG Fix default CanViewType not correctly affecting new records

### DIFF
--- a/code/SecureFileExtension.php
+++ b/code/SecureFileExtension.php
@@ -53,6 +53,15 @@ class SecureFileExtension extends DataExtension {
 		// fallback to Apache
 		return $registeredConfigs['Apache'];
 	}
+	
+	public function getCanViewType() {
+		// In case that there is no parent to inherit from, map Inherit to Anyone
+		$canViewType = $this->owner->getField('CanViewType');
+		if(!$this->owner->ParentID && $canViewType === 'Inherit') {
+			return 'Anyone';
+		}
+		return $canViewType;
+	}
 
 	function canView($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();

--- a/tests/SecureFileExtensionTest.php
+++ b/tests/SecureFileExtensionTest.php
@@ -5,6 +5,7 @@ class SecureFileExtensionTest extends SapphireTest {
 
 	public function testAnyonePermissions() {
 		$folder = $this->objFromFixture('Folder', 'anyone');
+		$this->assertEquals('Anyone', $folder->CanViewType);
 		$this->assertTrue($folder->canView());
 
 		Session::set('loggedInAs', null);
@@ -14,6 +15,7 @@ class SecureFileExtensionTest extends SapphireTest {
 	public function testInheritPermissions() {
 		$folder = $this->objFromFixture('Folder', 'child-viewergroups-restricted');
 		Session::set('loggedInAs', null);
+		$this->assertEquals('Inherit', $folder->CanViewType);
 		$this->assertFalse($folder->canView());
 
 		Session::set('loggedInAs', $this->idFromFixture('Member', 'member-1'));
@@ -26,10 +28,22 @@ class SecureFileExtensionTest extends SapphireTest {
 	public function testLoggedInPermissions() {
 		$folder = $this->objFromFixture('Folder', 'loggedin');
 		Session::set('loggedInAs', null);
+		$this->assertEquals('LoggedInUsers', $folder->CanViewType);
 		$this->assertFalse($folder->canView());
 
 		Session::set('loggedInAs', $this->idFromFixture('Member', 'member-2'));
 		$this->assertTrue($folder->canView());
+	}
+	
+	public function testDefaultPermissions() {
+		$folder = $this->objFromFixture('Folder', 'default-root');
+		Session::set('loggedInAs', null);
+		$this->assertEquals('Anyone', $folder->CanViewType);
+		$this->assertTrue($folder->canView());
+
+		$subfolder = $this->objFromFixture('Folder', 'default-child');
+		$this->assertEquals('Inherit', $subfolder->CanViewType);
+		$this->assertTrue($subfolder->canView());
 	}
 
 }

--- a/tests/SecureFileExtensionTest.yml
+++ b/tests/SecureFileExtensionTest.yml
@@ -14,6 +14,7 @@ Folder:
     CanViewType: Anyone
   loggedin:
     CanViewType: LoggedInUsers
+  default-root:
   viewergroups:
     CanViewType: OnlyTheseUsers
     ViewerGroups: =>Group.test-group
@@ -23,6 +24,8 @@ Folder:
   child-viewergroups-open:
     CanViewType: Anyone
     Parent: =>Folder.viewergroups
+  default-child:
+    Parent: =>Folder.default-root
 File:
   test:
     Name: test-file


### PR DESCRIPTION
Previously if a new folder was created in the root level it would have a DB default of 'Inherit' assigned to 'CanViewType', but this value isn't visible on the edit form due to it's lack of a parent. This fix maps the 'Inherit' value for root level folders to 'Anyone'.

Since the root folder 'assets' can't have access permissions assigned, it doesn't make much sense to represent subfolders as though they can inherit from this.

cc @hafriedlander

ref: ORB-33
