### PR TITLE
ENHANCEMENT Only call ob_end_flush() if there is an output buffer to flush

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -84,7 +84,10 @@ class SecureFileController extends Controller {
 		}
 
 		// Clear PHP buffer, otherwise the script will try to allocate memory for entire file.
-		ob_end_flush();
+		while (ob_get_level() > 0) {
+			ob_end_flush();
+		}
+
 		// Prevent blocking of the session file by PHP. Without this the user can't visit another page of the same
 		// website during download (see http://konrness.com/php5/how-to-prevent-blocking-php-requests/)
 		session_write_close();


### PR DESCRIPTION
Avoids triggering E_NOTICE.  Solves https://github.com/silverstripe-labs/silverstripe-secureassets/issues/15
