### PR TITLE
If file doesn't exist on the filesystem throw 404

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -64,7 +64,11 @@ class SecureFileController extends Controller {
 	 */
 	public function sendFile($file) {
 		$path = $file->getFullPath();
-
+		
+		if(!file_exists($path)) {
+			return $this->httpError(404);
+		}
+		
 		if(SapphireTest::is_running_test()) {
 			return file_get_contents($path);
 		}


### PR DESCRIPTION
When using the module server error logs are potentially full of harmless* 404's for files that exist as records in the database but no longer attached to the filesystem for whatever reason. Ideally files should exist if the database record does but we're seeing this on 2-3 sites. 

Developers could use the onBeforeSendFile hook to add their own reporting for these errors.