### PR TITLE
FIX: Don't allow potentially malicious files to be executed inline

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -42,7 +42,7 @@ class SecureFileController extends Controller {
 		}
 
 		header('Content-Description: File Transfer');
-		header('Content-Disposition: inline; filename=' . basename($path));
+		header('Content-Disposition: attachment; filename=' . basename($path));
 		header('Content-Length: ' . $file->getAbsoluteSize());
 		header('Content-Type: ' . HTTP::get_mime_type($file->getRelativePath()));
 		header('Content-Transfer-Encoding: binary');


### PR DESCRIPTION
When `Content-disposition: inline` is used, files (images, malicious SWF files etc.) will be executed on the domain that the file was served from. They may therefore be able to steal cookies etc. If the user is forced to download the file, even if that file eventually opens in the browser, it will be opened from a file:// context and therefore not able to steal cookies or otherwise break the website.