### PR TITLE
SECURITY: Correctly set Content-disposition header

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -16,6 +16,18 @@ class SecureFileController extends Controller {
 	private static $min_download_bandwidth = 50; // [in kilobytes per second]
 
 	/**
+	 * @var string The Content-disposition for any files served by secureassets.
+	 * @config
+	 *
+	 * The default is 'attachment', which will force the browser to treat any file as a download. Other useful values
+	 * are 'inline' which will force the browser to treat any file as embeddable (e.g. display a JPG file in the
+	 * browser). Note that this has security implications for files that the browser can render (e.g. SWF files) that
+	 * can do malicious things in the website's context. Other less typical Content-disposition options are outlined by
+	 * the IANA here: http://www.iana.org/assignments/cont-disp/cont-disp.xhtml
+	 */
+	private static $content_disposition = 'attachment';
+
+	/**
 	 * Process all incoming requests passed to this controller, checking
 	 * that the file exists and passing the file through if possible.
 	 */
@@ -73,9 +85,12 @@ class SecureFileController extends Controller {
 			return file_get_contents($path);
 		}
 
+		$disposition = $this->config()->content_disposition;
+		if(!$disposition) $disposition = 'attachment';
+
 		header('Content-Description: File Transfer');
 		// Quotes needed to retain spaces (http://kb.mozillazine.org/Filenames_with_spaces_are_truncated_upon_download)
-		header('Content-Disposition: inline; filename="' . basename($path) . '"');
+		header(sprintf('Content-Disposition: %s; filename="%s"', $disposition, basename($path)));
 		header('Content-Length: ' . $file->getAbsoluteSize());
 		header('Content-Type: ' . HTTP::get_mime_type($file->getRelativePath()));
 		header('Content-Transfer-Encoding: binary');

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -15,8 +15,30 @@ security restrictions to those folders.
 It is important to take note when using secure files attached to DataObjects which other users may be able to edit. If that user does not have permission to view the file attached, then it will not appear
 against that object, and modification may result in it being detached.
 
+### Pages
+
+Pages may be created in draft with secure files attached, but when this page is
+published you will need to change the permissions on each file to make them accessible.
+
+Try to avoid attaching secure images or other files to live pages (or other DataObjects)
+which may be publicly viewed, to avoid unnecessary access denied errors appearing.
+
+## Security of secure assets
+
+A common use-case for this module is to provide security for a directory of files
+uploaded by website visitors. This module will now by default enforce that all secure
+assets be downloaded by a visitor's browser if they are allowed access to the file. This
+is done with the 'Content-disposition' HTTP header.
+
+An override is available to restore the previous behaviour of allowing files to be
+loaded directly in the browser. To do so, set the
+`SecureFileController.content_disposition` config variable to `inline`. Please review
+and understand the security implications before doing so.
+
+## Other Considerations
+
 Securing files will cause extra load on your webserver and your database,
-as the framework will check the datatabase for access permissions, and pass the
+as the framework will check the database for access permissions, and pass the 
 file data through the framework when it is output to the user.
 
 It's also important to make sure that any .htaccess or web.config file


### PR DESCRIPTION
If Content-disposition header is set to inline, then malicious files stored in
the secured folder can be run in the logged-in user's context (e.g. HTML files
that run some AJAX to modify things in the CMS). This change forces the
'attachment' disposition by default that ensures the browser is forced to
download these files rather than displaying them inline. A further fix might be
to use mime validation instead of a single-purpose rule, to allow e.g. image
files to use inline. New configuration option added to allow the default to be
changed if required.

Thanks to Chris McCurley of Aura Information Security for reporting this issue.