### PR TITLE
SECURITY: Ensure appropriate Cache-control headers are set.

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -79,8 +79,10 @@ class SecureFileController extends Controller {
 		header('Content-Length: ' . $file->getAbsoluteSize());
 		header('Content-Type: ' . HTTP::get_mime_type($file->getRelativePath()));
 		header('Content-Transfer-Encoding: binary');
-		// Fixes IE6,7,8 file downloads over HTTPS bug (http://support.microsoft.com/kb/812935)
-		header('Pragma: ');
+
+		// Ensure we enforce no-cache headers consistently, so that files accesses aren't cached by CDN/edge networks
+		header('Pragma: no-cache');
+		header('Cache-Control: private, no-cache, no-store');
 
 		if ($this->config()->min_download_bandwidth) {
 			// Allow the download to last long enough to allow full download with min_download_bandwidth connection.


### PR DESCRIPTION
Fix the cache headers to ensure that files served through SecureFileController
are never cached. This ensures that even if the website is fronted by a
CDN/edge caching network, all requests for secure assets should always be
served dynamically, and therefore all users will be checked to ensure they have
the correct permissions.

Previously, if an administrator viewed a file, some CDNs may have mistakenly
cached the response, meaning that anyone guessing the filename could download
it without being authenticated.