### PR TITLE
Add a default security setting that applies to the assets folder

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,5 +12,5 @@ SecureAssets:
   Defaults:
     Permission: 'Anyone'
     Groups:
-      - 'Administrators'
-      - 'Content Authors'
+      - 'administrators'
+      - 'content-authors'

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -8,3 +8,9 @@ File:
 Director:
   rules:
     'assets': 'SecureFileController'
+SecureAssets:
+  Defaults:
+    Permission: 'Anyone'
+    Groups:
+      - 'Administrators'
+      - 'Content Authors'

--- a/code/SecureFileExtension.php
+++ b/code/SecureFileExtension.php
@@ -53,12 +53,6 @@ class SecureFileExtension extends DataExtension {
 		// fallback to Apache
 		return $registeredConfigs['Apache'];
 	}
-	
-	public function getCanViewType() {
-		// In case that there is no parent to inherit from, map Inherit to Anyone
-		$canViewType = $this->owner->getField('CanViewType');
-		return $canViewType;
-	}
 
 	public function canView($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) {

--- a/code/SecureFileExtension.php
+++ b/code/SecureFileExtension.php
@@ -70,7 +70,7 @@ class SecureFileExtension extends DataExtension {
 					return (bool)$member;
 				case 'Inherit':
 					if ($this->owner->ParentID) return $this->owner->Parent()->canView($member);
-					else return $this->defaultPermissions($member);
+					else return $this->owner->defaultPermissions($member);
 				case 'OnlyTheseUsers':
 					if ($member && $member->inGroups($this->owner->ViewerGroups())) return true;
 					else return false;
@@ -90,7 +90,7 @@ class SecureFileExtension extends DataExtension {
 			return $file->Parent()->canView($member);
 		}
 
-		return $this->defaultPermissions($member);
+		return $this->owner->defaultPermissions($member);
 	}
 
 	/**
@@ -100,7 +100,7 @@ class SecureFileExtension extends DataExtension {
 	 * @param Member $member
 	 * @return boolean
 	 */
-	protected function defaultPermissions($member = null) {
+	public function defaultPermissions($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
 			$member = Member::currentUser();
 		}

--- a/code/SecureFileExtension.php
+++ b/code/SecureFileExtension.php
@@ -93,6 +93,13 @@ class SecureFileExtension extends DataExtension {
 		return $this->defaultPermissions($member);
 	}
 
+	/**
+	 * Checks for any default access permissions and tests against them if found. Default permssions are set via the 
+	 * Config system.
+	 *
+	 * @param Member $member
+	 * @return boolean
+	 */
 	protected function defaultPermissions($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
 			$member = Member::currentUser();

--- a/tests/SecureFileExtensionTest.php
+++ b/tests/SecureFileExtensionTest.php
@@ -38,12 +38,25 @@ class SecureFileExtensionTest extends SapphireTest {
 	public function testDefaultPermissions() {
 		$folder = $this->objFromFixture('Folder', 'default-root');
 		Session::set('loggedInAs', null);
-		$this->assertEquals('Anyone', $folder->CanViewType);
+		$this->assertEquals('Inherit', $folder->CanViewType);
 		$this->assertTrue($folder->canView());
 
 		$subfolder = $this->objFromFixture('Folder', 'default-child');
 		$this->assertEquals('Inherit', $subfolder->CanViewType);
 		$this->assertTrue($subfolder->canView());
+	}
+
+	public function testRestrictedDefaultPermissions() {
+		$folder = $this->objFromFixture('Folder', 'default-root');
+		Session::set('loggedInAs', null);
+		$this->assertTrue($folder->canView());
+
+		Config::inst()->update('SecureAssets', 'Defaults', array('Permission' => 'LoggedInUsers'));
+		$this->assertFalse($folder->canView());
+
+		$subfolder = $this->objFromFixture('Folder', 'default-child');
+		$this->assertEquals('Inherit', $subfolder->CanViewType);
+		$this->assertFalse($subfolder->canView());
 	}
 
 }


### PR DESCRIPTION
This PR adds the ability to define a default access level to the assets folder and any folder that inherits its access from assets (e.g. a assets/folder set to inherit).

Currently the code looks for yml in the format of:
```yml
SecureAssets:
  Defaults:
    Permission: 'Anyone'
    Groups:
      - 'Administrators'
      - 'Content Authors'
```
The naming was picked as it seems to make sense but it may be worth changing it to line up under one the the Secure Assets classes.