### PR TITLE
BUG Fix issue with subsites blocking download of assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 
 env:
   - DB=MYSQL CORE_RELEASE=3.2
@@ -22,13 +21,14 @@ matrix:
       env: DB=MYSQL CORE_RELEASE=3.1
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
+    - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.3 SUBSITES=1
 
 before_script:
   - composer self-update || true
   - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+  - "if [ \"$SUBSITES\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
+  - "if [ \"$SUBSITES\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/subsites; fi"
   - cd ~/builds/ss
   - composer install
 

--- a/tests/SecureFileControllerSubsitesTest.php
+++ b/tests/SecureFileControllerSubsitesTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Test secure files that belong to subsites
+ */
+class SecureFileControllerSubsitesTest extends FunctionalTest
+{
+    protected static $fixture_file = 'SecureFileControllerSubsitesTest.yml';
+
+    public function setUp() {
+        // Reset to default
+        if(class_exists('Subsite', false)) {
+            Subsite::$use_session_subsiteid = true;
+            Subsite::$force_subsite = null;
+        } else {
+            $this->skipTest = true;
+        }
+
+		parent::setUp();
+
+        if($this->skipTest) {
+            $this->markTestSkipped('This test requires subsites');
+        }
+
+		if(!file_exists(ASSETS_PATH)) {
+            mkdir(ASSETS_PATH);
+        }
+
+		/* Create a test files for each of the fixture references */
+		$fileIDs = $this->allFixtureIDs('File');
+		foreach($fileIDs as $fileID) {
+			$file = DataObject::get_by_id('File', $fileID);
+            $path = $file->getFullPath();
+			$fh = fopen($path, "w");
+			fwrite($fh, str_repeat('x',1000000));
+			fclose($fh);
+		}
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+        // Reset to default
+        if(class_exists('Subsite', false)) {
+            Subsite::$use_session_subsiteid = true;
+            Subsite::$force_subsite = null;
+        }
+
+		/* Remove the test files that we've created */
+		$fileIDs = $this->allFixtureIDs('File');
+		foreach($fileIDs as $fileID) {
+			$file = DataObject::get_by_id('File', $fileID);
+            $path = $file->getFullPath();
+			if(file_exists($path)) {
+                unlink($path);
+            }
+		}
+	}
+
+    /**
+     * Avoid subsites filtering on fixture fetching.
+     */
+    public function objFromFixture($class, $id)
+    {
+        Subsite::disable_subsite_filter(true);
+        $obj = parent::objFromFixture($class, $id);
+        Subsite::disable_subsite_filter(false);
+
+        return $obj;
+    }
+
+    public function testFileSubsiteAccessible() {
+        // Files are accessible in public subsite
+        Subsite::changeSubsite(0);
+        $subsite1 = $this->idFromFixture('Subsite', 'subsite1');
+        $subsite2 = $this->idFromFixture('Subsite', 'subsite2');
+        $this->logInWithPermission('ADMIN');
+
+        /** @var File $file1 */
+        $file1 = $this->objFromFixture('File', 'file1');
+        /** @var File $file2 */
+        $file2 = $this->objFromFixture('File', 'file1');
+
+        // Both files accessible
+		$content = $this->get($file1->Link());
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+		$content = $this->get($file2->Link());
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+
+        // Test with subsite1
+        Subsite::changeSubsite($subsite1);
+
+        // Both files accessible
+		$content = $this->get($file1->Link());
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+		$content = $this->get($file2->Link());
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+
+        // Test with subsite1
+        Subsite::changeSubsite($subsite2);
+
+        // Both files accessible
+		$content = $this->get($file1->Link());
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+		$content = $this->get($file2->Link());
+		$this->assertContains('xxxxx', $content->getBody());
+		$this->assertTrue($content->getStatusCode() === 200);
+    }
+
+}

--- a/tests/SecureFileControllerSubsitesTest.yml
+++ b/tests/SecureFileControllerSubsitesTest.yml
@@ -1,0 +1,14 @@
+Subsite:
+  subsite1:
+    Title: 'First Subsite'
+  subsite2:
+    Title: 'Second Subsite'
+File:
+  file1:
+    Name: test-file
+    Filename: assets/FileTest.txt
+    SubsiteID: =>Subsite.subsite1
+  file2:
+    Name: test-file2
+    Filename: assets/FileTest2.txt
+    SubsiteID: =>Subsite.subsite2

--- a/tests/SecureFileControllerTest.php
+++ b/tests/SecureFileControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 class SecureFileControllerTest extends FunctionalTest {
-	static $fixture_file = 'SecureFileControllerTest.yml';
+	protected static $fixture_file = 'SecureFileControllerTest.yml';
 
 	public function testCanDownloadPermissivePermission() {
 		File::add_extension('SecureFileExtensionTest_PermissiveFileExtension');
@@ -33,7 +33,9 @@ class SecureFileControllerTest extends FunctionalTest {
 	public function setUp() {
 		parent::setUp();
 
-		if(!file_exists(ASSETS_PATH)) mkdir(ASSETS_PATH);
+		if(!file_exists(ASSETS_PATH)) {
+            mkdir(ASSETS_PATH);
+        }
 
 		/* Create a test files for each of the fixture references */
 		$fileIDs = $this->allFixtureIDs('File');


### PR DESCRIPTION
At the moment, subsites stops filtering of files based on the current subsite.

Since this module replaces the "direct file access" which by its nature was subsite agnostic, the secure file controller needs to also ignore it.